### PR TITLE
feat(reportEmbed): Improve the user ID limit message

### DIFF
--- a/src/Listener/ReportListener.ts
+++ b/src/Listener/ReportListener.ts
@@ -316,7 +316,13 @@ export default class ReportListener {
         const links         = report.links.map((x) => `<${x}>`);
         const tags          = report.tags.map((x) => x.name);
 
-        let description = `**Users:** \n${reportedUsers.slice(0, 10).join(', ')} (limited to 10)`;
+        let description = '**Users:**\n';
+        if (reportedUsers.length > 10) {
+            description += `${reportedUsers.slice(0, 10).join(', ')} (limited to 10 out of ${reportedUsers.length})`;
+        } else {
+            description += reportedUsers.join(', ');
+        }
+
         if (report.reason) {
             description += `\n\n**Reason:** ${report.reason}`;
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -279,7 +279,7 @@ export default class ReportPlugin extends AbstractPlugin {
         'setup',
         'Set up reports to go to a channel the bot is in.',
         `Set up reports to go to a channel the bot is in.
-        
+
 onlyUsersInGuild should be \`true\` or \`yes\` (anything else is no). If set to no, will alert you to ALL reports.
 
 tags should be \`all\` or a list (comma or space delimited) list of tags from: {prefix}tags
@@ -519,8 +519,8 @@ tags should be \`all\` or a list (comma or space delimited) list of tags from: {
         const embed = new Embed();
 
         embed.author      = {name: `Report ID: ${report.id}`};
-        embed.description = `**Users:** ${reportedUsers.slice(0, 10).join(', ')}
-        
+        embed.description = `**Users:** ${reportedUsers.length > 10 ? `${reportedUsers.slice(0, 10).join(', ')} (limited to 10 out of ${reportedUsers.length})` : reportedUsers.slice(0, 10).join(', ')}
+
 **Reason:** ${report.reason}
 
 **Links:** ${links.length === 0 ? 'None' : links.join('\n')}


### PR DESCRIPTION
Only show the "limited to 10" message if there are more than 10 user IDs, otherwise omit it. Also show the total amount if it has been limited.